### PR TITLE
Create docker based development environment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM debian:jessie
+COPY docker /docker
+RUN sh docker/setup.sh
+EXPOSE 80 1080
+CMD ["/usr/bin/supervisord", "-n"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  gdpr:
+    build: .
+    ports:
+    - "80:80"
+    - "1080:1080"
+    volumes:
+    - .:/var/www/wordpress/wp-content/plugins/GDPRWP-Plugin
+    - ../GDPRWP-Plugin-Sample:/var/www/wordpress/wp-content/plugins/GDPRWP-Plugin-Sample

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,51 @@
+# WordPress single site rules.
+# Designed to be included in any server {} block.
+# Upstream to abstract backend connection(s) for php
+upstream php {
+  server unix:/run/php/php7.0-fpm.sock;
+}
+
+server {
+    listen 80;
+    server_name gdpr-test-site.test;
+
+    ## Your only path reference.
+    root /var/www/wordpress;
+    ## This should be in your http block and if it is, it's not needed here.
+    index index.php;
+
+    location /mailcatcher/ {
+        proxy_pass http://127.0.0.1:1080/;
+    }
+
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
+    }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+	location / {
+		# This is cool because no php is touched for static content.
+		# include the "?$args" part so non-default permalinks doesn't break when using query string
+		try_files $uri $uri/ /index.php?$args;
+	}
+
+	location ~ \.php$ {
+		#NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+		include fastcgi.conf;
+		fastcgi_intercept_errors on;
+		fastcgi_pass php;
+		fastcgi_buffers 16 16k;
+		fastcgi_buffer_size 32k;
+	}
+
+	location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+		expires max;
+		log_not_found off;
+	}
+}

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -1,0 +1,29 @@
+# Docker Development Environment
+
+NOTE: This is not a production-ready container. Please don't use it in production.
+
+These files, along with `/Dockerfile` and `/docker-compose.yml` can be used to build a standalone container with 
+everything you need to run and test this plugin. The single container contains nginx, php-fpm, 
+mysql and a few nice-to-have tools for testing and development.
+
+## Building the Docker Image
+
+`docker-compose build`
+
+### Running Docker Image
+
+In your host file, add the following:
+
+`127.0.0.1   gdpr-test-site.test`
+
+Then start the container with:
+
+`docker-compose up`
+
+The test site can now be accessed at `http://gdpr-test-site.test`, and mailcatcher can be accessed at `http://gdpr-test-site.test:1080/`
+
+## Logging into the Running Container
+
+To log into the container:
+
+`docker-compose exec gdpr bash`

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -e
+export DEBIAN_FRONTEND=noninteractive
+
+# Install nginx, php, mariadb, nodejs
+apt-get update -y
+apt-get install -y --no-install-recommends apt-utils curl nano
+
+echo "Installing additional libs..."
+echo "deb http://packages.dotdeb.org jessie all" | tee /etc/apt/sources.list.d/dotdeb.list
+echo "deb-src http://packages.dotdeb.org jessie all" | tee /etc/apt/sources.list.d/dotdeb-src.list
+curl -sSkL https://www.dotdeb.org/dotdeb.gpg -o dotdeb.gpg
+apt-key add dotdeb.gpg
+
+echo "Installing packages..."
+apt-get update -y
+apt-get install -y --no-install-recommends unzip supervisor php7.0-fpm php7.0-imagick \
+  php7.0-curl php7.0-mysql php7.0-mcrypt php7.0-xml php7.0-memcached php7.0-mbstring \
+  nginx mariadb-server build-essential sqlite3 libsqlite3-dev git ruby ruby-dev
+
+echo "Install mailcatcher..."
+gem install mailcatcher
+sed -i 's/.*sendmail_path.*/sendmail_path = \/usr\/bin\/env catchmail -f admin@gdpr-compliance\.test/g' /etc/php/7.0/fpm/php.ini
+sed -i 's/.*sendmail_path.*/sendmail_path = \/usr\/bin\/env catchmail -f admin@gdpr-compliance\.text/g' /etc/php/7.0/cli/php.ini
+
+echo "Installing wordpress..."
+curl -sSkL https://wordpress.org/latest.tar.gz | tar -xzvC /var/www
+
+echo "Installing wp-cli..."
+curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+chmod +x wp-cli.phar
+mv wp-cli.phar /usr/local/bin/wp
+alias wp="wp --allow-root"
+
+echo "Installing composer..."
+curl -sSkL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+echo "Setting up database..."
+service mysql start
+mysql -e "CREATE DATABASE gdpr;"
+mysql -e "GRANT ALL PRIVILEGES ON gdpr.* TO gdpr@localhost IDENTIFIED BY 'gdpr';"
+echo "Database created, importing all .sql files..."
+cat docker/*.sql | mysql gdpr
+apt-get install -y phpmyadmin
+service mysql stop
+ln -s /usr/share/phpmyadmin /var/www/wordpress/
+
+mkdir -p /var/log/supervisor
+
+echo "Setting up configs..."
+mv docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+mv docker/nginx.conf /etc/nginx/conf.d/nginx.conf
+mv docker/wp-config.php /var/www/wordpress/wp-config.php
+
+echo "Cleaning up..."
+rm -rf docker
+apt-get autoremove -y

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,26 @@
+[supervisord]
+nodaemon=true
+
+[program:mysql]
+command=mysqld_safe
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+autorestart=true
+
+[program:php-fpm]
+command=php-fpm7.0 -F
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+autorestart=true
+
+[program:nginx]
+command=nginx -g "daemon off;"
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+autorestart=true
+
+[program:mailcatcher]
+command=mailcatcher -f -v --ip 0.0.0.0
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+autorestart=true

--- a/docker/wp-config.php
+++ b/docker/wp-config.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * The base configuration for WordPress
+ *
+ * The wp-config.php creation script uses this file during the
+ * installation. You don't have to use the web site, you can
+ * copy this file to "wp-config.php" and fill in the values.
+ *
+ * This file contains the following configurations:
+ *
+ * * MySQL settings
+ * * Secret keys
+ * * Database table prefix
+ * * ABSPATH
+ *
+ * @link https://codex.wordpress.org/Editing_wp-config.php
+ *
+ * @package WordPress
+ */
+
+// ** MySQL settings - You can get this info from your web host ** //
+/** The name of the database for WordPress */
+define('DB_NAME', 'gdpr');
+
+/** MySQL database username */
+define('DB_USER', 'gdpr');
+
+/** MySQL database password */
+define('DB_PASSWORD', 'gdpr');
+
+/** MySQL hostname */
+define('DB_HOST', 'localhost');
+
+/** Database Charset to use in creating database tables. */
+define('DB_CHARSET', 'utf8');
+
+/** The Database Collate type. Don't change this if in doubt. */
+define('DB_COLLATE', '');
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ *
+ * @since 2.6.0
+ */
+define('AUTH_KEY',         'OoI[%YSsP^>H*|{P*qv`[6qO|UQUZ][hAM=.5V)UL6~-?}eKJ?G PwkscP2??}g_');
+define('SECURE_AUTH_KEY',  'j|GgMhx<-K#TeW(Spt2tAX2<F+(hWW|f)WXqSfwd@3-d(Yc+:T;Ya-uJa-Vp+iXs');
+define('LOGGED_IN_KEY',    'Cq,n-^Ed/c<e{[5,$ZB@l) bE9#M<?xi% 2>YX-o[TvAS6(l%:Dft9`~=@5/Q,E|');
+define('NONCE_KEY',        '5QE?+|^C#e $y0 F^4tKc--p$8vQ:CPcRoZO_W_L:/_YoK0Yoyy5l^+X~k7}B4={');
+define('AUTH_SALT',        'qLdG}0+pChv~VR4p%Fu|IMO(}@]r%++ucUC}wy )5+ns:jZ;%^Gr/*nI(Ob>L[*e');
+define('SECURE_AUTH_SALT', 'J_q1xEZ)%W>ECZvp m&!++s]+glmj8[dP_XXSML-e|I@&#mg4,fZ8q981~nu7Eh+');
+define('LOGGED_IN_SALT',   ')SJ!/pAVP91m8IzWo$K&hC<lkj8`;khvU0Bh9Q-<{w0_xET|/^BBEI9!JJ,FpUQc');
+define('NONCE_SALT',       '[GUi]SV2SV.:x@t6H-`~P?,^f?{J.K@|B I~krrxIsK:.YeWLtKn#nGmte_CQTJ|');
+
+/**#@-*/
+
+/**
+ * WordPress Database Table prefix.
+ *
+ * You can have multiple installations in one database if you give each
+ * a unique prefix. Only numbers, letters, and underscores please!
+ */
+$table_prefix  = 'wp_';
+
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * For information on other constants that can be used for debugging,
+ * visit the Codex.
+ *
+ * @link https://codex.wordpress.org/Debugging_in_WordPress
+ */
+define('WP_DEBUG', true);
+define('WP_DEBUG_LOG', true);
+define('WP_DEBUG_DISPLAY', true);
+
+/* That's all, stop editing! Happy blogging. */
+
+/** Absolute path to the WordPress directory. */
+if ( !defined('ABSPATH') )
+	define('ABSPATH', dirname(__FILE__) . '/');
+
+/** Sets up WordPress vars and included files. */
+require_once(ABSPATH . 'wp-settings.php');


### PR DESCRIPTION
Note: This is in progress. Don't merge just yet.

Copied docker files over from a different project. This sets a docker
image that contains both the gdpr plugin and the sample plugin

This will allow users to easily create a running development environment.

Note: I'm having trouble getting mailcatcher to work with WordPress. It works fine from the command line, php, and wp-cli. Help needed :-)